### PR TITLE
Add dataset request API and email form

### DIFF
--- a/migrations/20240612_add_dataset_download_emails.sql
+++ b/migrations/20240612_add_dataset_download_emails.sql
@@ -1,0 +1,7 @@
+-- Migration: store emails used for dataset downloads
+CREATE TABLE IF NOT EXISTS dataset_download_emails (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL,
+  confirmed_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW())
+);
+ALTER TABLE dataset_download_emails ENABLE ROW LEVEL SECURITY;

--- a/src/app/api/request-dataset/route.ts
+++ b/src/app/api/request-dataset/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createClient } from '@supabase/supabase-js';
+
+export async function handleRequest(req: Request) {
+  try {
+    const { email } = await req.json();
+    if (!email) {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 });
+    }
+
+    const cookieStore = await cookies();
+    let userId: string | null = null;
+
+    const authHeader = req.headers.get('authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.substring(7);
+      const supabase = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        { global: { headers: { Authorization: `Bearer ${token}` } } }
+      );
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+      if (user) {
+        userId = user.id;
+      }
+    }
+
+    if (!userId) {
+      userId = cookieStore.get('anonymous_session_id')?.value || null;
+    }
+
+    if (!userId) {
+      userId = `anon-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      cookieStore.set('anonymous_session_id', userId, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 365
+      });
+    }
+
+    const admin = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_KEY!
+    );
+
+    await admin.from('dataset_download_emails').insert({ email });
+    await admin.from('dataset_downloads').insert({ user_id: userId });
+
+    const url = process.env.DATASET_URL;
+    if (!url) {
+      return NextResponse.json({ error: 'Dataset URL not configured' }, { status: 500 });
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error('Error in request-dataset API:', err);
+    return NextResponse.json({ error: 'Invalid request' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  return handleRequest(req);
+}

--- a/src/app/dataset/page.tsx
+++ b/src/app/dataset/page.tsx
@@ -1,33 +1,37 @@
 'use client';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { useUser } from '@/contexts/UserContext';
-import { fetchWithRetry } from '@/lib/api';
+import { Input } from '@/components/ui/input';
+import { postJsonWithRetry } from '@/lib/api';
 import { logEvent } from '@/lib/eventLogger';
 
 export default function DatasetPage() {
-  const { user } = useUser();
+  const [email, setEmail] = useState('');
+  const [confirmEmail, setConfirmEmail] = useState('');
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const datasetInfo = {
     description:
       'Dataset of AI vs human story comparisons in Parquet format. Size ~100MB.',
   };
 
-  const handleDownload = async () => {
+  const handleDownload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (email !== confirmEmail) return;
     setLoading(true);
+    setError(null);
     try {
-      const res = await fetchWithRetry('/api/download-dataset');
+      const res = await postJsonWithRetry('/api/request-dataset', { email });
       if (res.ok) {
         const { url } = await res.json();
         void logEvent('dataset_download');
         window.location.href = url;
-      } else if (res.status === 401) {
-        alert('Please log in to download.');
       } else {
-        alert('Failed to get download link');
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || 'Failed to get download link');
       }
     } catch {
-      alert('Failed to get download link');
+      setError('Failed to get download link');
     } finally {
       setLoading(false);
     }
@@ -39,13 +43,26 @@ export default function DatasetPage() {
       <p className="text-sm text-gray-600 dark:text-gray-400">
         {datasetInfo.description}
       </p>
-      {user ? (
-        <Button onClick={handleDownload} disabled={loading} className="w-fit">
-          {loading ? 'Preparing...' : 'Download Dataset'}
+      <form onSubmit={handleDownload} className="flex flex-col gap-4">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="email"
+          placeholder="Confirm Email"
+          value={confirmEmail}
+          onChange={e => setConfirmEmail(e.target.value)}
+          required
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" disabled={loading || email !== confirmEmail} className="w-fit">
+          {loading ? 'Preparing...' : 'Get Download Link'}
         </Button>
-      ) : (
-        <p>You must be logged in to download the dataset.</p>
-      )}
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `dataset_download_emails` table migration
- add `/api/request-dataset` to log emails and downloads
- update dataset page to use email confirmation form

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_685549cab544832aa65a9d21ebd4b99b