### PR TITLE
Add MVP mode flag

### DIFF
--- a/config/app-config.json
+++ b/config/app-config.json
@@ -33,7 +33,8 @@
       "showHelpButton": true,
       "enableDarkMode": false,
       "defaultTheme": "light"
-    }
+    },
+    "mvpMode": true
   },
   
   "models": {

--- a/config/index.ts
+++ b/config/index.ts
@@ -47,6 +47,7 @@ export interface AppConfig {
       enableDarkMode: boolean;
       defaultTheme: string;
     };
+    mvpMode: boolean;
   };
   models: {
     defaultProvider: string;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { NavigationBar } from "@/components/NavigationBar";
 import { OnboardingDebugPanel } from "@/components/OnboardingDebugPanel";
 import { AuthDebugPanel } from "@/components/AuthDebugPanel";
 import { PageViewLogger } from "@/components/PageViewLogger";
-import { serverConfig as config } from "@/lib/server-config";
+import { getServerConfig } from "@/lib/server-config";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -33,6 +33,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const config = getServerConfig();
   return (
     <html lang="en">
       <body
@@ -42,10 +43,10 @@ export default function RootLayout({
           <UserProvider>
             <PageViewLogger />
             <main className="min-h-screen p-4 sm:p-6 lg:p-8">
-              <NavigationBar />
+              {!config.features.mvpMode && <NavigationBar />}
               {children}
             </main>
-            {config.debugMode && (
+              {config.app.debugMode && (
               <>
                 <OnboardingDebugPanel />
                 <AuthDebugPanel />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,14 @@ import { Button } from "@/components/ui/button";
 import ModeCardLinks from "@/components/ModeCardLinks";
 import { authors } from "@/lib/authors";
 import { SignupEncouragement } from "@/components/SignupEncouragement";
+import MvpPage from "@/components/MvpPage";
+import { getServerConfig } from "@/lib/server-config";
 
 export default function HomePage() {
+  const config = getServerConfig();
+  if (config.features.mvpMode) {
+    return <MvpPage />;
+  }
   return (
     <div className="max-w-3xl mx-auto space-y-8">
       <section className="text-center space-y-4">
@@ -30,7 +36,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <SignupEncouragement trigger="banner" />
+      {!config.features.mvpMode && <SignupEncouragement trigger="banner" />}
 
       <div className="flex justify-center gap-4">
         <Link href="/resources">

--- a/src/components/MvpPage.tsx
+++ b/src/components/MvpPage.tsx
@@ -1,0 +1,10 @@
+export default function MvpPage() {
+  return (
+    <div className="max-w-3xl mx-auto text-center py-20 space-y-4">
+      <h1 className="text-3xl font-bold">Coming Soon</h1>
+      <p className="text-muted-foreground">
+        We&apos;re working hard on new features. Check back later!
+      </p>
+    </div>
+  );
+}

--- a/src/components/SignupEncouragement.tsx
+++ b/src/components/SignupEncouragement.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useUser } from "@/contexts/UserContext";
 import { shouldEncourageSignup } from "@/lib/auth-utils-client";
+import { clientConfig as config } from "@/lib/config-client";
 import { LoginForm } from "./LoginForm";
 import { 
   User, 
@@ -23,10 +24,10 @@ interface SignupEncouragementProps {
   showDismiss?: boolean;
 }
 
-export function SignupEncouragement({ 
-  trigger = 'banner', 
+export function SignupEncouragement({
+  trigger = 'banner',
   onDismiss,
-  showDismiss = true 
+  showDismiss = true
 }: SignupEncouragementProps) {
   const { user } = useUser();
   const [showLoginForm, setShowLoginForm] = useState(false);
@@ -37,6 +38,11 @@ export function SignupEncouragement({
     // This effect runs only on the client, after the component has mounted.
     setIsClient(true);
   }, []);
+
+  // Hide entirely in MVP mode
+  if (config.mvpMode) {
+    return null;
+  }
 
   // Don't show if user is authenticated, component is dismissed, or we are on the server.
   if (!isClient || !shouldEncourageSignup(user) || isDismissed) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
   showDashboardButton: boolean;
   showSpeedModeToggle: boolean;
   showScoreDisplay: boolean;
+  mvpMode: boolean;
 }
 
 // Configuration values - these should match your config/app-config.json
@@ -30,6 +31,7 @@ export const config: AppConfig = {
   showDashboardButton: false,
   showSpeedModeToggle: false,
   showScoreDisplay: false,
+  mvpMode: false,
 };
 
 export default config;

--- a/src/lib/config-client.ts
+++ b/src/lib/config-client.ts
@@ -14,6 +14,7 @@ export interface ClientConfig {
   showDashboardButton: boolean;
   showSpeedModeToggle: boolean;
   showScoreDisplay: boolean;
+  mvpMode: boolean;
 }
 
 // Default client configuration - these values should match app-config.json defaults
@@ -31,6 +32,7 @@ export const clientConfig: ClientConfig = {
   showDashboardButton: false,
   showSpeedModeToggle: false,
   showScoreDisplay: false,
+  mvpMode: false,
 };
 
 // Legacy export for backward compatibility

--- a/src/lib/server-config.ts
+++ b/src/lib/server-config.ts
@@ -50,6 +50,7 @@ export interface ServerAppConfig {
       enableDarkMode: boolean;
       defaultTheme: string;
     };
+    mvpMode: boolean;
   };
   models: {
     defaultProvider: string;


### PR DESCRIPTION
## Summary
- add `mvpMode` flag to config files
- expose the flag on client/server config utilities
- show simple `MvpPage` when mvpMode is enabled
- hide `NavigationBar` and `SignupEncouragement` when in MVP mode

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` *(fails: waiting for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_685549c8bc5c832a946a0369dfe40e82